### PR TITLE
Remove footnotes and footnote lists

### DIFF
--- a/scholarly-article.json
+++ b/scholarly-article.json
@@ -34,7 +34,7 @@
       "label": "Unspecified",
       "comment": "A section that is unknown or otherwise unspecified.",
       "subClassOf": [],
-      "disjointWith": ["sa:Abstract", "sa:Introduction", "sa:MaterialsAndMethods", "sa:Results", "sa:Discussion", "sa:Conclusion", "sa:Acknowledgements", "sa:ReferenceList", "sa:Reference", "sa:FootnoteList", "sa:Footnote", "sa:Formula", "sa:Image", "sa:Video", "sa:Audio", "sa:Table", "sa:Funding"],
+      "disjointWith": ["sa:Abstract", "sa:Introduction", "sa:MaterialsAndMethods", "sa:Results", "sa:Discussion", "sa:Conclusion", "sa:Acknowledgements", "sa:ReferenceList", "sa:Reference", "sa:Formula", "sa:Image", "sa:Video", "sa:Audio", "sa:Table", "sa:Funding"],
       "status": "testing"
     },
 
@@ -165,31 +165,6 @@
       "disjointWith": ["sa:Unspecified"],
       "status": "testing"
     },
-
-    {
-      "@id": "sa:FootnoteList",
-      "@type": "rdfs:Class",
-      "label": "Footnotes",
-      "comment": "A list of items each representing a footnote.",
-      "subClassOf": [
-        "http://purl.org/spar/doco/List"
-      ],
-      "disjointWith": ["sa:Unspecified"],
-      "status": "testing"
-    },
-    {
-      "@id": "sa:Footnote",
-      "@type": "rdfs:Class",
-      "label": "Footnote",
-      "sameAs": "http://purl.org/spar/doco/Footnote",
-      "comment": "A structural item that allows the author to make an additional remark, usually outside the main body of the text.",
-      "subClassOf": [
-        "http://purl.org/spar/deo/DiscourseElement"
-      ],
-      "disjointWith": ["sa:Unspecified"],
-      "status": "testing"
-    },
-
     {
       "@id": "sa:Formula",
       "@type": "rdfs:Class",


### PR DESCRIPTION
They were replaced them with DPUB-ARIA (as provisionally expected to become).